### PR TITLE
Correct naming

### DIFF
--- a/connectors/aws/lambda/src/main/kotlin/com/river/connector/aws/lambda/LambdaAsyncClientExt.kt
+++ b/connectors/aws/lambda/src/main/kotlin/com/river/connector/aws/lambda/LambdaAsyncClientExt.kt
@@ -1,6 +1,6 @@
 package com.river.connector.aws.lambda
 
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.future.await
 import software.amazon.awssdk.core.SdkBytes
@@ -47,7 +47,7 @@ fun LambdaAsyncClient.invokeFlow(
     parallelism: Int = 1
 ): Flow<InvokeResponse> =
     upstream
-        .mapParallel(parallelism) { content ->
+        .mapAsync(parallelism) { content ->
             invoke { builder ->
                 builder
                     .functionName(functionName)

--- a/connectors/aws/ses/src/main/kotlin/com/river/connector/aws/sqs/SesExt.kt
+++ b/connectors/aws/ses/src/main/kotlin/com/river/connector/aws/sqs/SesExt.kt
@@ -1,6 +1,6 @@
 package com.river.connector.aws.sqs
 
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.future.await
@@ -18,6 +18,6 @@ fun SesV2AsyncClient.sendEmailFlow(
     parallelism: Int = 1
 ): Flow<SendEmailResponse> =
     upstream
-        .mapParallel(parallelism) {
+        .mapAsync(parallelism) {
             sendEmail(it).await()
         }

--- a/connectors/aws/sns/src/main/kotlin/com/river/connector/aws/sns/SnsAsyncClientExt.kt
+++ b/connectors/aws/sns/src/main/kotlin/com/river/connector/aws/sns/SnsAsyncClientExt.kt
@@ -61,7 +61,7 @@ fun SnsAsyncClient.publishFlow(
         .flatMapConcat { arn ->
             upstream
                 .chunked(groupStrategy)
-                .mapParallel(parallelism) { chunk ->
+                .mapAsync(parallelism) { chunk ->
                     val entries = chunk.mapIndexed { index, publishMessageRequest ->
                         publishMessageRequest.asEntry("$index")
                     }

--- a/connectors/aws/sqs/src/main/kotlin/com/river/connector/aws/sqs/SqsAsyncClientExt.kt
+++ b/connectors/aws/sqs/src/main/kotlin/com/river/connector/aws/sqs/SqsAsyncClientExt.kt
@@ -98,7 +98,7 @@ fun SqsAsyncClient.sendMessageFlow(
         upstream
             .map { it.asMessageRequestEntry() }
             .chunked(groupStrategy)
-            .mapParallel(parallelism) { entries ->
+            .mapAsync(parallelism) { entries ->
                 val response =
                     sendMessageBatch { it.queueUrl(url).entries(entries) }
                         .await()
@@ -170,7 +170,7 @@ fun SqsAsyncClient.changeMessageVisibilityFlow(
     flowOf(queueUrl).flatMapConcat { url ->
         upstream
             .chunked(groupStrategy)
-            .mapParallel(parallelism) { messages ->
+            .mapAsync(parallelism) { messages ->
                 changeMessageVisibilityBatch {
                     it.queueUrl(url)
 
@@ -229,7 +229,7 @@ fun SqsAsyncClient.deleteMessagesFlow(
     flowOf(queueUrl).flatMapConcat { url ->
         upstream
             .chunked(groupStrategy)
-            .mapParallel(parallelism) { messages ->
+            .mapAsync(parallelism) { messages ->
                 deleteMessageBatch {
                     logger.info("Deleting ${messages.size} messages from queue $queueUrl")
 

--- a/connectors/azure/queue-storage/src/main/kotlin/com/river/connector/azure/queue/storage/QueueStorageExt.kt
+++ b/connectors/azure/queue-storage/src/main/kotlin/com/river/connector/azure/queue/storage/QueueStorageExt.kt
@@ -5,7 +5,7 @@ import com.azure.storage.queue.models.QueueMessageItem
 import com.azure.storage.queue.models.SendMessageResult
 import com.river.connector.azure.queue.storage.model.SendMessageRequest
 import com.river.core.ParallelismStrategy
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import com.river.core.poll
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
@@ -71,7 +71,7 @@ fun QueueAsyncClient.deleteMessagesFlow(
     parallelism: Int = 100,
 ): Flow<Unit> =
     upstream
-        .mapParallel(parallelism) {
+        .mapAsync(parallelism) {
             deleteMessage(it.messageId, it.popReceipt).awaitFirstOrNull()
             Unit
         }
@@ -98,7 +98,7 @@ fun QueueAsyncClient.sendMessagesFlow(
     parallelism: Int = 100,
 ): Flow<SendMessageResult> =
     upstream
-        .mapParallel(parallelism) {
+        .mapAsync(parallelism) {
             sendMessageWithResponse(it.text, it.visibilityTimeout?.toJavaDuration(), it.ttl?.toJavaDuration())
                 .awaitFirst()
                 .value

--- a/connectors/elasticsearch/src/main/kotlin/com/river/connector/elasticsearch/ElasticsearchAsyncClientExt.kt
+++ b/connectors/elasticsearch/src/main/kotlin/com/river/connector/elasticsearch/ElasticsearchAsyncClientExt.kt
@@ -70,7 +70,7 @@ fun <T> ElasticsearchAsyncClient.indexFlow(
 ): Flow<BulkResponseItem> =
     upstream
         .chunked(groupStrategy)
-        .mapParallel(parallelism) { chunk ->
+        .mapAsync(parallelism) { chunk ->
             BulkRequest.Builder()
                 .also { builder ->
                     chunk.forEach { document ->

--- a/connectors/elasticsearch/src/main/kotlin/com/river/connector/elasticsearch/PaginatedSearch.kt
+++ b/connectors/elasticsearch/src/main/kotlin/com/river/connector/elasticsearch/PaginatedSearch.kt
@@ -48,7 +48,7 @@ sealed interface PaginatedSearch {
                                 .build()
                         }
                     }
-                    .mapParallel(parallelism) { request ->
+                    .mapAsync(parallelism) { request ->
                         request?.let {
                             client.search(it, clazz)
                                 .await()

--- a/connectors/jms/src/main/kotlin/com/river/connector/jms/JmsExt.kt
+++ b/connectors/jms/src/main/kotlin/com/river/connector/jms/JmsExt.kt
@@ -4,9 +4,9 @@ package com.river.connector.jms
 
 import com.river.connector.jms.model.*
 import com.river.core.flatten
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import com.river.core.repeat
-import com.river.core.unorderedMapParallel
+import com.river.core.unorderedMapAsync
 import com.river.util.pool.ObjectPool
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -74,7 +74,7 @@ fun ConnectionFactory.consume(
 
         emitAll(
             repeat(contextPool)
-                .unorderedMapParallel(parallelism) {
+                .unorderedMapAsync(parallelism) {
                     val instance = it.borrow()
                     val (_, consumer) = instance.instance
 
@@ -144,7 +144,7 @@ fun ConnectionFactory.sendToDestination(
                 }
 
         upstream
-            .mapParallel(parallelism) { send(it) }
+            .mapAsync(parallelism) { send(it) }
             .collect { emit(Unit) }
     }
 }

--- a/connectors/mongodb/src/main/kotlin/com/river/connector/mongodb/MongoCollectionExt.kt
+++ b/connectors/mongodb/src/main/kotlin/com/river/connector/mongodb/MongoCollectionExt.kt
@@ -9,7 +9,7 @@ import com.mongodb.client.result.UpdateResult
 import com.mongodb.reactivestreams.client.MongoCollection
 import com.river.core.GroupStrategy
 import com.river.core.chunked
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.reactive.asFlow
@@ -38,7 +38,7 @@ fun <T> MongoCollection<T>.insert(
     flow: Flow<T>,
     parallelism: Int = 1,
 ): Flow<InsertOneResult> =
-    flow.mapParallel(parallelism) { insertOne(it).awaitFirst() }
+    flow.mapAsync(parallelism) { insertOne(it).awaitFirst() }
 
 /**
  * Inserts many documents into a MongoDB collection using a flow of documents, batching them by the provided chunkStrategy.
@@ -66,7 +66,7 @@ fun <T> MongoCollection<T>.insertMany(
 ): Flow<InsertManyResult> =
     flow
         .chunked(groupStrategy)
-        .mapParallel(parallelism) { insertMany(it, options).asFlow() }
+        .mapAsync(parallelism) { insertMany(it, options).asFlow() }
         .flattenConcat()
 
 /**
@@ -91,7 +91,7 @@ fun MongoCollection<Document>.update(
     flow: Flow<Document>,
     filter: Bson,
     parallelism: Int = 1,
-) = flow.mapParallel(parallelism) { updateOne(filter, it).awaitFirst() }
+) = flow.mapAsync(parallelism) { updateOne(filter, it).awaitFirst() }
 
 /**
  * Updates many documents in a MongoDB collection using a flow of update documents, a filter, and batching by the provided chunkStrategy.
@@ -120,7 +120,7 @@ fun MongoCollection<Document>.updateMany(
 ): Flow<UpdateResult> =
     flow
         .chunked(groupStrategy)
-        .mapParallel(parallelism) { updateMany(filter, it).asFlow() }
+        .mapAsync(parallelism) { updateMany(filter, it).asFlow() }
         .flattenConcat()
 
 /**
@@ -145,7 +145,7 @@ fun <T> MongoCollection<T>.replace(
     flow: Flow<T>,
     filter: Bson,
     parallelism: Int = 1,
-): Flow<UpdateResult> = flow.mapParallel(parallelism) { replaceOne(filter, it).awaitFirst() }
+): Flow<UpdateResult> = flow.mapAsync(parallelism) { replaceOne(filter, it).awaitFirst() }
 
 /**
  * Replaces documents in a MongoDB collection using a flow of pairs containing a filter and a document.
@@ -168,7 +168,7 @@ fun <T> MongoCollection<T>.replace(
     flow: Flow<Pair<Bson, T>>,
     parallelism: Int = 1,
 ): Flow<UpdateResult> =
-    flow.mapParallel(parallelism) { (filter, document) -> replaceOne(filter, document).awaitFirst() }
+    flow.mapAsync(parallelism) { (filter, document) -> replaceOne(filter, document).awaitFirst() }
 
 /**
  * Finds documents in a MongoDB collection that match the specified BSON query and returns them as a flow.

--- a/connectors/rdbms/jdbc/src/main/kotlin/com/river/connector/rdbms/jdbc/JdbcExt.kt
+++ b/connectors/rdbms/jdbc/src/main/kotlin/com/river/connector/rdbms/jdbc/JdbcExt.kt
@@ -5,7 +5,7 @@ package com.river.connector.rdbms.jdbc
 import com.river.core.GroupStrategy
 import com.river.core.GroupStrategy.*
 import com.river.core.chunked
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.invoke
@@ -78,7 +78,7 @@ fun <T> Jdbc.singleUpdate(
     prepare: suspend PreparedStatement.(T) -> Unit = {}
 ): Flow<Int> =
     upstream
-        .mapParallel(parallelism) { item ->
+        .mapAsync(parallelism) { item ->
         connectionPool.use {
             IO {
                 it.prepareStatement(sql)
@@ -120,7 +120,7 @@ fun <T> Jdbc.batchUpdate(
 ): Flow<Int> =
     upstream
         .chunked(groupStrategy)
-        .mapParallel(parallelism) { chunk ->
+        .mapAsync(parallelism) { chunk ->
             connectionPool.use {
                 IO {
                     logger.debug("Running $sql with ${chunk.size} elements.")

--- a/connectors/rdbms/r2dbc/src/main/kotlin/com/river/connector/rdbms/r2dbc/R2dbcFlowExt.kt
+++ b/connectors/rdbms/r2dbc/src/main/kotlin/com/river/connector/rdbms/r2dbc/R2dbcFlowExt.kt
@@ -5,7 +5,7 @@ package com.river.connector.rdbms.r2dbc
 import com.river.connector.rdbms.r2dbc.model.Returning
 import com.river.core.GroupStrategy
 import com.river.core.chunked
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.Result
 import io.r2dbc.spi.Row
@@ -123,7 +123,7 @@ fun <T> Connection.singleUpdate(
     prepare: Statement.(T) -> Unit = {}
 ): Flow<Long> =
     upstream
-        .mapParallel(parallelism) { item ->
+        .mapAsync(parallelism) { item ->
             createStatement(sql)
                 .also { statement -> prepare(statement, item) }
                 .execute()
@@ -217,7 +217,7 @@ fun <T> Connection.batchUpdate(
 ): Flow<Result> =
     upstream
         .chunked(groupStrategy)
-        .mapParallel(parallelism) { items ->
+        .mapAsync(parallelism) { items ->
             createStatement(sql)
                 .let {
                     when (returning) {
@@ -279,7 +279,7 @@ fun <T> Connection.batchUpdate(
 ): Flow<Result> =
     upstream
         .chunked(groupStrategy)
-        .mapParallel(parallelism) { items ->
+        .mapAsync(parallelism) { items ->
             createBatch()
                 .also { batch -> items.forEach { batch.add(query(it)) } }
                 .execute()

--- a/connectors/twilio/src/main/kotlin/com/river/connector/twilio/TwilioExt.kt
+++ b/connectors/twilio/src/main/kotlin/com/river/connector/twilio/TwilioExt.kt
@@ -2,10 +2,10 @@ package com.river.connector.twilio
 
 import com.river.connector.twilio.model.CreateMessage
 import com.river.connector.twilio.model.Message
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import kotlinx.coroutines.flow.Flow
 
 fun TwilioMessageHttpApi.sendMessageFlow(
     upstream: Flow<CreateMessage>,
     parallelism: Int = 1
-): Flow<Message> = upstream.mapParallel(parallelism) { createMessage(it) }
+): Flow<Message> = upstream.mapAsync(parallelism) { createMessage(it) }

--- a/core/src/main/kotlin/com/river/core/AsyncExt.kt
+++ b/core/src/main/kotlin/com/river/core/AsyncExt.kt
@@ -45,8 +45,8 @@ infix fun <T> List<CompletableDeferred<T>>.completeAllWith(result: Result<List<T
  * @param f A suspend function to apply to each element of the iterable.
  * @return A [List] containing the flattened results of applying [f] to each element of the iterable.
  */
-suspend fun <T, R> Iterable<T>.flatMapParallel(f: suspend (T) -> Iterable<R>): List<R> =
-    mapParallel { f(it) }.flatten()
+suspend fun <T, R> Iterable<T>.flatMapAsync(f: suspend (T) -> Iterable<R>): List<R> =
+    mapAsync { f(it) }.flatten()
 
 /**
  * Transforms the elements of the iterable in parallel using the provided [f] function with a specified
@@ -56,10 +56,10 @@ suspend fun <T, R> Iterable<T>.flatMapParallel(f: suspend (T) -> Iterable<R>): L
  * @param f A suspend function to apply to each element of the iterable.
  * @return A [List] containing the flattened results of applying [f] to each element of the iterable.
  */
-suspend fun <T, R> Iterable<T>.flatMapParallel(
+suspend fun <T, R> Iterable<T>.flatMapAsync(
     concurrency: Int,
     f: suspend (T) -> Iterable<R>
-): List<R> = mapParallel(concurrency) { f(it) }.flatten()
+): List<R> = mapAsync(concurrency) { f(it) }.flatten()
 
 /**
  * Transforms the elements of the iterable in parallel using the provided [f] function.
@@ -67,7 +67,7 @@ suspend fun <T, R> Iterable<T>.flatMapParallel(
  * @param f A suspend function to apply to each element of the iterable.
  * @return A [List] containing the results of applying [f] to each element of the iterable.
  */
-suspend fun <T, R> Iterable<T>.mapParallel(f: suspend (T) -> R): List<R> =
+suspend fun <T, R> Iterable<T>.mapAsync(f: suspend (T) -> R): List<R> =
     coroutineScope { map { async { f(it) } }.awaitAll() }
 
 /**
@@ -78,7 +78,7 @@ suspend fun <T, R> Iterable<T>.mapParallel(f: suspend (T) -> R): List<R> =
  * @param f A suspend function to apply to each element of the iterable.
  * @return A [List] containing the results of applying [f] to each element of the iterable.
  */
-suspend fun <T, R> Iterable<T>.mapParallel(
+suspend fun <T, R> Iterable<T>.mapAsync(
     concurrency: Int,
     f: suspend ConcurrencyInfo.(T) -> R
-): List<R> = asFlow().mapParallel(concurrency, f).toList()
+): List<R> = asFlow().mapAsync(concurrency, f).toList()

--- a/core/src/main/kotlin/com/river/core/FlowExt.kt
+++ b/core/src/main/kotlin/com/river/core/FlowExt.kt
@@ -72,54 +72,54 @@ fun <T> Flow<Iterable<T>>.flatten(): Flow<T> =
 
 /**
  * Performs the provided [f] action concurrently on each item emitted by the flow. The action
- * is applied with the specified [concurrencyLevel].
+ * is applied with the specified [concurrency].
  *
- * @param concurrencyLevel The maximum number of concurrent invocations of the action [f].
+ * @param concurrency The maximum number of concurrent invocations of the action [f].
  * @param f The action to apply to each item emitted by the flow.
  * @return A [Flow] of items with the action applied concurrently.
  */
-inline fun <T> Flow<T>.onEachParallel(
-    concurrencyLevel: Int,
+inline fun <T> Flow<T>.onEachAsync(
+    concurrency: Int,
     crossinline f: suspend ConcurrencyInfo.(T) -> Unit
-): Flow<T> = mapParallel(concurrencyLevel) { it.also { f(it) } }
+): Flow<T> = mapAsync(concurrency) { it.also { f(it) } }
 
 /**
  * Performs the provided [f] action concurrently on each item emitted by the flow. The action
- * is applied with the specified [concurrencyLevel]. The order of items might not be preserved.
+ * is applied with the specified [concurrency]. The order of items might not be preserved.
  *
- * @param concurrencyLevel The maximum number of concurrent invocations of the action [f].
+ * @param concurrency The maximum number of concurrent invocations of the action [f].
  * @param f The action to apply to each item emitted by the flow.
  * @return A [Flow] of items with the action applied concurrently and possibly unordered.
  */
-inline fun <T> Flow<T>.unorderedOnEachParallel(
-    concurrencyLevel: Int,
+inline fun <T> Flow<T>.unorderedOnEachAsync(
+    concurrency: Int,
     crossinline f: suspend ConcurrencyInfo.(T) -> Unit
-): Flow<T> = unorderedMapParallel(concurrencyLevel) { it.also { f(it) } }
+): Flow<T> = unorderedMapAsync(concurrency) { it.also { f(it) } }
 
 /**
  * Collects the flow and performs the provided [f] action concurrently on each item emitted by the
- * flow. The action is applied with the specified [concurrencyLevel].
+ * flow. The action is applied with the specified [concurrency].
  *
- * @param concurrencyLevel The maximum number of concurrent invocations of the action [f].
+ * @param concurrency The maximum number of concurrent invocations of the action [f].
  * @param f The action to apply to each item emitted by the flow.
  */
-suspend inline fun <T> Flow<T>.collectParallel(
-    concurrencyLevel: Int,
+suspend inline fun <T> Flow<T>.collectAsync(
+    concurrency: Int,
     crossinline f: suspend ConcurrencyInfo.(T) -> Unit
-): Unit = onEachParallel(concurrencyLevel, f).collect()
+): Unit = onEachAsync(concurrency, f).collect()
 
 /**
  * Collects the flow and performs the provided [f] action concurrently on each item emitted by the
- * flow. The action is applied with the specified [concurrencyLevel]. The order of items might
+ * flow. The action is applied with the specified [concurrency]. The order of items might
  * not be preserved.
  *
- * @param concurrencyLevel The maximum number of concurrent invocations of the action [f].
+ * @param concurrency The maximum number of concurrent invocations of the action [f].
  * @param f The action to apply to each item emitted by the flow.
  */
-suspend inline fun <T> Flow<T>.unorderedCollectParallel(
-    concurrencyLevel: Int,
+suspend inline fun <T> Flow<T>.unorderedCollectAsync(
+    concurrency: Int,
     crossinline f: suspend ConcurrencyInfo.(T) -> Unit
-): Unit = unorderedOnEachParallel(concurrencyLevel, f).collect()
+): Unit = unorderedOnEachAsync(concurrency, f).collect()
 
 /**
  * Counts the number of items emitted by the flow within the specified [duration] window.
@@ -133,72 +133,71 @@ suspend fun <T> Flow<T>.countOnWindow(duration: Duration): Int {
 }
 
 /**
- * The [mapParallel] function is similar to the [map] function
+ * The [mapAsync] function is similar to the [map] function
  * since it transforms each element via the [transform] function.
  *
- * It works, however, in a parallel way, which means that multiple elements can be processed at the same time,
+ * It works, however, asynchronously, which means that multiple elements can be processed at the same time,
  * especially useful for more intensive tasks.
  *
- * Use [concurrencyLevel] to configure the parallelism number.
+ * Use [concurrency] to configure the concurrency number.
  *
  * One thing to note is that the order of the elements is preserved,
  * so the output flow will contain the same elements as the input flow,
  * but with the values transformed according to the provided function.
  */
-fun <T, R> Flow<T>.mapParallel(
-    concurrencyLevel: Int,
+fun <T, R> Flow<T>.mapAsync(
+    concurrency: Int,
     transform: suspend ConcurrencyInfo.(T) -> R
-): Flow<R> = MapParallelFlow(this, concurrencyLevel, transform)
+): Flow<R> = MapAsyncFlow(this, concurrency, transform)
 
 /**
- * The [unorderedMapParallel] function is similar to the [mapParallel] function in that it transforms each element
- * in a parallel way using the provided [f] function. However, unlike [mapParallel], this function does not guarantee
+ * The [unorderedMapAsync] function is similar to the [mapAsync] function in that it transforms each element
+ * iasynchronously using the provided [f] function. However, unlike [mapAsync], this function does not guarantee
  * that the output elements will be in the same order as the input elements. This means that this function can be
- * significantly faster than [mapParallel] because it does not have to preserve order.
+ * significantly faster than [mapAsync] because it does not have to preserve order.
  *
- * Use [concurrencyLevel] to configure the parallelism number.
+ * Use [concurrency] to configure the maximum number of concurrent coroutines that can be executed.
  */
-fun <T, R> Flow<T>.unorderedMapParallel(
-    concurrencyLevel: Int,
+fun <T, R> Flow<T>.unorderedMapAsync(
+    concurrency: Int,
     f: suspend ConcurrencyInfo.(T) -> R
-): Flow<R> = UnorderedMapParallelFlow(this, concurrencyLevel, f)
+): Flow<R> = UnorderedMapAsyncFlow(this, concurrency, f)
 
 /**
- * The [flatMapParallel] function is similar to the [flatMap] function but works in a parallel way
+ * The [flatMapAsync] function is similar to the [flatMap] function but works asynchronously
  * to transform each element of the [Flow], which is an Iterable, with the provided [f] function.
  *
- * This function transforms each Iterable element of the input Flow by applying the [f] function in a
- * parallel way. This means that multiple elements can be processed at the same time, especially useful
- * for more intensive tasks.
+ * This function transforms each Iterable element of the input Flow by applying the [f] function asynchronously.
+ * This means that multiple elements can be processed at the same time, especially useful for more intensive tasks.
  *
- * Use [concurrencyLevel] to configure the parallelism number.
+ * Use [concurrency] to configure the maximum number of concurrent coroutines that can be executed.
  *
  * The output of this function is a Flow of the transformed elements, where the order of the elements is preserved.
  * This means that the output Flow will contain the same elements as the input Flow, but with each element
  * transformed according to the provided function.
  */
-fun <T, R> Flow<Iterable<T>>.flatMapParallel(
-    concurrencyLevel: Int,
+fun <T, R> Flow<Iterable<T>>.flatMapAsync(
+    concurrency: Int,
     f: suspend ConcurrencyInfo.(Iterable<T>) -> Iterable<R>
-): Flow<R> = mapParallel(concurrencyLevel, f).flatten()
+): Flow<R> = mapAsync(concurrency, f).flatten()
 
 /**
- * The [unorderedFlatMapParallel] function is similar to the [flatMapParallel] function but does not guarantee
+ * The [unorderedFlatMapAsync] function is similar to the [flatMapAsync] function but does not guarantee
  * the order of the output elements.
  *
- * This function transforms each Iterable element of the input Flow by applying the [f] function in a parallel way.
+ * This function transforms each Iterable element of the input Flow by applying the [f] function asynchronously.
  * This means that multiple elements can be processed at the same time, especially useful for more intensive tasks.
  *
- * Use [concurrencyLevel] to configure the parallelism number.
+ * Use [concurrency] to configure the maximum number of concurrent coroutines that can be executed.
  *
  * The output of this function is a Flow of the transformed elements, where the order of the elements is not preserved.
  * This means that the output Flow may not contain the elements in the same order as the input Flow.
- * However, this function can be significantly faster than [flatMapParallel] because it does not have to preserve order.
+ * However, this function can be significantly faster than [flatMapAsync] because it does not have to preserve order.
  */
-fun <T, R> Flow<Iterable<T>>.unorderedFlatMapParallel(
-    concurrencyLevel: Int,
+fun <T, R> Flow<Iterable<T>>.unorderedFlatMapAsync(
+    concurrency: Int,
     f: suspend ConcurrencyInfo.(Iterable<T>) -> Iterable<R>
-): Flow<R> = mapParallel(concurrencyLevel, f).flatten()
+): Flow<R> = mapAsync(concurrency, f).flatten()
 
 /**
  * The [collectAsync] function launches a coroutine to collect the elements emitted by the current [Flow] in an asynchronous way.
@@ -274,7 +273,7 @@ fun <T> repeat(item: T): Flow<T> =
     }
 
 /**
- * Allows the [Flow] to be collected and transformed into another [Flow] in parallel. The
+ * Allows the [Flow] to be collected and transformed into another [Flow] asynchronously. The
  * transformed [Flow] is collected asynchronously in the provided [scope]. The original flow
  * and the transformed flow share the same buffer with the specified [bufferCapacity],
  * [onBufferOverflow] policy, and [onUndeliveredElement] handler.

--- a/core/src/main/kotlin/com/river/core/internal/Broadcast.kt
+++ b/core/src/main/kotlin/com/river/core/internal/Broadcast.kt
@@ -1,7 +1,7 @@
 package com.river.core.internal
 
 import com.river.core.collectAsync
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
@@ -23,7 +23,7 @@ internal class Broadcast<T>(
         upstream
             .onCompletion { channels.forEach { it.close() } }
             .collectAsync(scope) { element ->
-                channels.mapParallel { it.send(element) }
+                channels.mapAsync { it.send(element) }
             }
     }
 

--- a/core/src/main/kotlin/com/river/core/internal/MapAsyncFlow.kt
+++ b/core/src/main/kotlin/com/river/core/internal/MapAsyncFlow.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Semaphore
 import org.slf4j.LoggerFactory
 
-internal class MapParallelFlow<T, R>(
+internal class MapAsyncFlow<T, R>(
     private val upstream: Flow<T>,
     private val concurrencyLevel: Int,
     private val f: suspend ConcurrencyInfo.(T) -> R

--- a/core/src/main/kotlin/com/river/core/internal/PollingFlow.kt
+++ b/core/src/main/kotlin/com/river/core/internal/PollingFlow.kt
@@ -4,7 +4,7 @@ package com.river.core.internal
 
 import com.river.core.ParallelismInfo
 import com.river.core.ParallelismStrategy
-import com.river.core.mapParallel
+import com.river.core.mapAsync
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -63,7 +63,7 @@ internal sealed interface PollingFlow<T> : Flow<T> {
                     )
 
                     (1..lastParallelismInfo.currentParallelism)
-                        .mapParallel { producer(lastParallelismInfo) }
+                        .mapAsync { producer(lastParallelismInfo) }
                         .onEach { if (!emptyResultOnResponse) emptyResultOnResponse = it.isEmpty() }
                         .flatten()
                         .also {

--- a/core/src/main/kotlin/com/river/core/internal/UnorderedMapAsyncFlow.kt
+++ b/core/src/main/kotlin/com/river/core/internal/UnorderedMapAsyncFlow.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import org.slf4j.LoggerFactory
 
-internal class UnorderedMapParallelFlow<T, R>(
+internal class UnorderedMapAsyncFlow<T, R>(
     private val upstream: Flow<T>,
     private val concurrencyLevel: Int,
     private val f: suspend ConcurrencyInfo.(T) -> R

--- a/core/src/test/kotlin/com/river/core/FlowExtKtTest.kt
+++ b/core/src/test/kotlin/com/river/core/FlowExtKtTest.kt
@@ -106,7 +106,7 @@ class FlowExtKtTest : FeatureSpec({
         scenario("Should allow a concurrency for item processing within the flow") {
             val (_, duration) = measureTimedValue {
                 flowOf(2, 4, 6, 8, 10, 12, 14, 16, 18, 20)
-                    .mapParallel(5) { delay(500.milliseconds) }
+                    .mapAsync(5) { delay(500.milliseconds) }
                     .collect()
             }
 


### PR DESCRIPTION
The word "parallel" is used incorrectly. See the difference between "concurrent", "parallel" and "asynchronous". 

We talk about parallelism only when two processes are executed at the same time, what means that two threads are processing those processes, so processor can process one on one core, and another one at the same time on another core. 

Concurrency includes parallelism, but it also includes a situation where two processes are executed interchangeably. Like when you start a couple of coroutines in a dispatcher with only one thread. 

Asynchronous is a word from a different world. A process is asynchronous when it is executed while a different process is executed. So the opposite of asynchronous is synchronous, witch means that one process waits for another. 

For the functions in here, I believe `Async` is the best suffix, because they start asynchronous processes. `Parallel` is certainly not correct, because if you execute them on a dispatcher limited to a single thread, they will not be executed in parallel. 

Instead of the `concurrencyLevel` parameter name, I would suggest using just `concurrency` for consistency with kotlinx.coroutines lib (see `flatMapMerge`). 

I wanted to rename functions on the rest of this lib, but man, this word is used many times. Nevertheless, I think it needs to be changed, and now is better than later. 

For testing `mapAsync` see 
https://github.com/MarcinMoskala/kotlin-coroutines-recipes/blob/master/src/commonTest/kotlin/MapAsyncTest.kt